### PR TITLE
Fix bug on GridController updates

### DIFF
--- a/lib/src/drag_select_grid_view/drag_select_grid_view.dart
+++ b/lib/src/drag_select_grid_view/drag_select_grid_view.dart
@@ -229,11 +229,13 @@ class DragSelectGridViewState extends State<DragSelectGridView>
   @override
   void initState() {
     super.initState();
-    final controller = _gridController;
-    if (controller != null) {
-      controller.addListener(_onSelectionChanged);
-      _selectionManager.selectedIndexes = controller.value.selectedIndexes;
-    }
+    _gridController?.addListener(_onSelectionChanged);
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _onSelectionChanged();
   }
 
   @override
@@ -298,6 +300,7 @@ class DragSelectGridViewState extends State<DragSelectGridView>
       if (!setEquals(controllerSelectedIndexes, selectedIndexes)) {
         _selectionManager.selectedIndexes = controllerSelectedIndexes;
         _updateLocalHistory();
+        setState(() {});
       }
     }
   }

--- a/test/src/drag_select_grid_view/drag_select_grid_view_test.dart
+++ b/test/src/drag_select_grid_view/drag_select_grid_view_test.dart
@@ -10,8 +10,8 @@ void main() {
   final gridFinder = find.byType(DragSelectGridView);
   final emptySpaceFinder = find.byKey(const ValueKey('empty-space'));
 
-  final firstItemFinder = find.byKey(const ValueKey('grid-item-0'));
-  final lastItemFinder = find.byKey(const ValueKey('grid-item-11'));
+  final firstItemFinder = find.byKey(_itemKey(0));
+  final lastItemFinder = find.byKey(_itemKey(11));
 
   late DragSelectGridViewState dragSelectState;
 
@@ -38,9 +38,8 @@ void main() {
               gridController: gridController,
               reverse: reverse ?? false,
               itemCount: 12,
-              itemBuilder: (_, index, __) => Container(
-                key: ValueKey('grid-item-$index'),
-              ),
+              itemBuilder: (_, index, selected) =>
+                  TestItem(index: index, selected: selected),
               gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
                 crossAxisCount: 4,
               ),
@@ -72,11 +71,11 @@ void main() {
     await tester.pumpWidget(widget);
     dragSelectState = tester.state(gridFinder);
 
-    final secondItemFinder = find.byKey(const ValueKey('grid-item-1'));
+    final secondItemFinder = find.byKey(_itemKey(1));
     mainAxisItemsDistance =
         tester.getCenter(secondItemFinder) - tester.getCenter(firstItemFinder);
 
-    final fifthItemFinder = find.byKey(const ValueKey('grid-item-4'));
+    final fifthItemFinder = find.byKey(_itemKey(4));
     crossAxisItemsDistance =
         tester.getCenter(fifthItemFinder) - tester.getCenter(firstItemFinder);
   }
@@ -975,19 +974,53 @@ void main() {
 
       testWidgets(
         "When creating a grid with pre-selected items, "
-        "then the pre-selected items get selected in the grid-state.",
+        "then the pre-selected items get selected in the grid-state, "
+        "and LocalHistory entry is created.",
         (tester) async {
           // When creating a grid with pre-selected items,
           final gridController =
               DragSelectGridViewController(Selection(const {0, 1}));
           await setUp(tester, gridController: gridController);
 
-          // then the pre-selected items get selected in the grid-state.
+          // then the pre-selected items get selected in the grid-state,
           expect(dragSelectState.isDragging, isFalse);
           expect(dragSelectState.isSelecting, isTrue);
           expect(dragSelectState.selectedIndexes, {0, 1});
+
+          // and LocalHistory entry is created.
+          final route = ModalRoute.of(tester.element(gridFinder));
+          expect(route!.canPop, isTrue);
         },
         skip: false,
+      );
+
+      testWidgets(
+        "Given a grid with a gridController, "
+        "and selection is already active"
+        "when the user updates the selection controller, "
+        "then the grid-state is updated accordingly.",
+        (tester) async {
+          // Given a grid with a gridController
+          final gridController = DragSelectGridViewController(
+            Selection(const {0}),
+          );
+          await setUp(tester, gridController: gridController);
+
+          // and selection is already active
+          expect(dragSelectState.isSelecting, isTrue);
+          expect(findItem(tester, 0).selected, isTrue);
+
+          // when the user updates the selection controller,
+          gridController.value = Selection(const {1, 3});
+          await tester.pumpAndSettle();
+
+          // then the grid-state is updated accordingly.
+          expect(dragSelectState.isSelecting, isTrue);
+          expect(dragSelectState.selectedIndexes, {1, 3});
+          expect(findItem(tester, 0).selected, isFalse);
+          expect(findItem(tester, 1).selected, isTrue);
+          expect(findItem(tester, 3).selected, isTrue);
+        },
       );
     });
 
@@ -1240,4 +1273,27 @@ void main() {
       skip: false,
     );
   });
+}
+
+class TestItem extends StatelessWidget {
+  final int index;
+  final bool selected;
+
+  TestItem({
+    required this.index,
+    required this.selected,
+  }) : super(key: _itemKey(index));
+
+  @override
+  Widget build(BuildContext context) {
+    return Container();
+  }
+}
+
+TestItem findItem(WidgetTester tester, int i) {
+  return tester.widget(find.byKey(_itemKey(i)));
+}
+
+Key _itemKey(int index) {
+  return ValueKey('grid-item-$index');
 }


### PR DESCRIPTION
This PR fixes two bugs:

- When a non-empty GridController is provided, the LocalHistory isn't populate and thus the back action will pop the entire route rather than cancelling selection
- Given a LocalHistory already present, when a GridController is updated programmatically, then widget will not update as expected

Let me know if you need more information,
Hope it helps :)